### PR TITLE
Create v2.3.0

### DIFF
--- a/v2.3.0
+++ b/v2.3.0
@@ -1,0 +1,435 @@
+openapi: 3.1.0
+info:
+  title: XYCLE Feedback Ops (Sheet.best)
+  version: 2.3.0
+servers:
+  - url: https://api.sheetbest.com
+
+components:
+  securitySchemes:
+    sheetbestApiKey:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+
+  schemas:
+    # ---------- Taxonomy: Subjects ----------
+    TaxonomySubject:
+      type: object
+      description: A single Subject row in the taxonomy.
+      required: [Subject_ID, Subject_Name, Status, Created_At, Updated_At]
+      properties:
+        Subject_ID:           { type: string, description: "UUID, subj_xxxx" }
+        Subject_Name:         { type: string, description: "Specific taxonomy subject name (ideally unique)" }
+        Synonyms:             { type: string, description: "Comma/semicolon-separated alternates" }
+        Status:               { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Category_ID:          { type: string, nullable: true, description: "FK to Categories (Status=Active)" }
+        Subcategory_ID:       { type: string, nullable: true, description: "FK to Subcategories (Status=Active)" }
+        Notes:                { type: string, description: "Free text; record merge actions here" }
+        Canonical_Subject_ID: { type: string, nullable: true, description: "FK to canonical Subject_ID when merged/deleted" }
+        Created_By:           { type: string, description: "Person or Machine who created the record" }
+        Created_At:           { type: string, description: "ISO-8601 timestamp" }
+        Updated_At:           { type: string, description: "ISO-8601 timestamp" }
+
+    TaxonomySubjectUpdate:
+      type: object
+      description: Partial update for Subject rows; include only fields you want to change.
+      minProperties: 1
+      additionalProperties: false
+      properties:
+        Subject_Name:         { type: string }
+        Synonyms:             { type: string }
+        Status:               { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Category_ID:          { type: string, nullable: true }
+        Subcategory_ID:       { type: string, nullable: true }
+        Notes:                { type: string }
+        Canonical_Subject_ID: { type: string, nullable: true }
+        Created_By:           { type: string }
+        Created_At:           { type: string }
+        Updated_At:           { type: string }
+
+    # ---------- Taxonomy: Categories ----------
+    TaxonomyCategory:
+      type: object
+      description: A single Category row in the taxonomy.
+      required: [Category_ID, Category_Name, Status, Created_At, Updated_At]
+      properties:
+        Category_Name:         { type: string, description: "High-level grouping" }
+        Category_ID:           { type: string, description: "UUID, like cat_001" }
+        Canonical_Category_ID: { type: string, nullable: true, description: "FK to canonical Category_ID when merged/deleted" }
+        Description:           { type: string, description: "Description of the category to guide mapping" }
+        Status:                { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Created_By:            { type: string, description: "Person or Machine who created the record" }
+        Created_At:            { type: string, description: "ISO-8601 timestamp" }
+        Updated_At:            { type: string, description: "ISO-8601 timestamp" }
+        Notes:                 { type: string, description: "Free text; record merge actions here" }
+
+    TaxonomyCategoryUpdate:
+      type: object
+      description: Partial update for Category rows; include only fields you want to change.
+      minProperties: 1
+      additionalProperties: false
+      properties:
+        Category_Name:         { type: string }
+        Canonical_Category_ID: { type: string, nullable: true }
+        Description:           { type: string }
+        Status:                { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Created_By:            { type: string }
+        Created_At:            { type: string }
+        Updated_At:            { type: string }
+        Notes:                 { type: string }
+
+    # ---------- Taxonomy: Subcategories ----------
+    TaxonomySubcategory:
+      type: object
+      description: A single Subcategory row in the taxonomy.
+      required: [Subcategory_ID, Subcategory_Name, Status, Created_At, Updated_At]
+      properties:
+        Subcategory_Name:         { type: string, description: "Lower-level grouping" }
+        Subcategory_ID:           { type: string, description: "UUID, like scat_0001" }
+        Category_ID:              { type: string, nullable: true, description: "FK to Categories (Status=Active)" }
+        Canonical_Subcategory_ID: { type: string, nullable: true, description: "FK to canonical Subcategory_ID when merged/deleted" }
+        Description:              { type: string, description: "Description to guide mapping" }
+        Status:                   { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Created_By:               { type: string, description: "Person or Machine who created the record" }
+        Created_At:               { type: string, description: "ISO-8601 timestamp" }
+        Updated_At:               { type: string, description: "ISO-8601 timestamp" }
+        Notes:                    { type: string, description: "Free text; record merge actions here" }
+
+    TaxonomySubcategoryUpdate:
+      type: object
+      description: Partial update for Subcategory rows; include only fields you want to change.
+      minProperties: 1
+      additionalProperties: false
+      properties:
+        Subcategory_Name:         { type: string }
+        Category_ID:              { type: string, nullable: true }
+        Canonical_Subcategory_ID: { type: string, nullable: true }
+        Description:              { type: string }
+        Status:                   { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Created_By:               { type: string }
+        Created_At:               { type: string }
+        Updated_At:               { type: string }
+        Notes:                    { type: string }
+
+    # ---------- Feedback Items (unchanged) ----------
+    FeedbackItem:
+      type: object
+      description: Canonical structured feedback row
+      required:
+        - Feedback_Item_ID
+        - Feedback_Item
+        - Quote
+        - Person
+        - Timestamp
+        - Type
+        - Subject_ID
+        - Created_At
+        - Updated_At
+      properties:
+        Feedback_Item_ID: { type: string, description: "UUID, like fb_xxxxxx" }
+        Feedback_Item:    { type: string, description: "Short summary (3–10 words)" }
+        Quote:            { type: string, description: "Verbatim excerpt" }
+        Person:           { type: string, description: "Customer/user name or Unknown" }
+        Timestamp:        { type: string, description: "YYYY-MM-DD HH:MM:SS or Unknown" }
+        Type:             { type: string, enum: ["Positive feedback", "Change request", "Needs clarification", "Market insight", "Opportunity"] }
+        Subject_ID:       { type: string, description: "UUID from Taxonomy where Status=Active" }
+        Source_Type:      { type: string, enum: ["Email", "Transcript", "Message", "Support ticket", "Unknown"] }
+        Source_Ref:       { type: string, description: "Source URL or stable key" }
+        Created_At:       { type: string, description: "ISO-8601 timestamp" }
+        Updated_At:       { type: string, description: "ISO-8601 timestamp" }
+
+    FeedbackItemUpdate:
+      type: object
+      description: Partial update for a single Feedback Item (tagging/retagging)
+      minProperties: 1
+      additionalProperties: false
+      properties:
+        Type:       { type: string, enum: ["Positive feedback", "Change request", "Needs clarification", "Market insight", "Opportunity"] }
+        Subject_ID: { type: string, description: "New canonical Subject_ID" }
+        Updated_At: { type: string, description: "ISO-8601 timestamp of this update" }
+
+    BulkFeedbackItemRetag:
+      type: object
+      description: Bulk retag all rows that currently match a Subject_ID
+      required: [Subject_ID, Updated_At]
+      additionalProperties: false
+      properties:
+        Subject_ID: { type: string, description: "New canonical Subject_ID to set" }
+        Updated_At: { type: string, description: "ISO-8601 timestamp" }
+
+security:
+  - sheetbestApiKey: []
+
+paths:
+  # ===================== SUBJECTS (Taxonomy) =====================
+  /sheets/895dac3e-2ad5-4f1a-96e7-ae12687b0cfa/tabs/Subjects:
+    get:
+      tags: [Taxonomy-Subjects]
+      operationId: listSubjects
+      summary: List all Subjects
+      parameters:
+        - in: query
+          name: _limit
+          schema: { type: integer, minimum: 1 }
+        - in: query
+          name: _offset
+          schema: { type: integer, minimum: 0 }
+        - in: query
+          name: _format
+          schema:
+            type: string
+            enum: [records, dict, list, series, split, index]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TaxonomySubject' }
+    post:
+      tags: [Taxonomy-Subjects]
+      operationId: createSubject
+      summary: Insert a new Subject row
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/TaxonomySubject' }
+      responses:
+        "200":
+          description: Inserted row(s)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TaxonomySubject' }
+
+  /sheets/895dac3e-2ad5-4f1a-96e7-ae12687b0cfa/tabs/Subjects/Subject_Name/{subject_name}:
+    get:
+      tags: [Taxonomy-Subjects]
+      operationId: getSubjectByName
+      summary: Fetch Subject rows that match a Subject_Name (exact match on display string)
+      parameters:
+        - in: path
+          name: subject_name
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TaxonomySubject' }
+
+  /sheets/895dac3e-2ad5-4f1a-96e7-ae12687b0cfa/tabs/Subjects/Subject_ID/{subject_id}:
+    patch:
+      tags: [Taxonomy-Subjects]
+      operationId: updateSubjectById
+      summary: Update fields for the row with the given Subject_ID (preferred)
+      parameters:
+        - in: path
+          name: subject_id
+          required: true
+          schema: { type: string }
+          description: Immutable Subject_ID value to match.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/TaxonomySubjectUpdate' }
+      responses:
+        "200":
+          description: Updated row(s)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TaxonomySubject' }
+
+  # ===================== CATEGORIES (Taxonomy) =====================
+  /sheets/895dac3e-2ad5-4f1a-96e7-ae12687b0cfa/tabs/Categories:
+    get:
+      tags: [Taxonomy-Categories]
+      operationId: listCategories
+      summary: Get Taxonomy - Categories
+      parameters:
+        - in: query
+          name: _limit
+          schema: { type: integer, minimum: 1 }
+        - in: query
+          name: _offset
+          schema: { type: integer, minimum: 0 }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TaxonomyCategory' }
+
+  /sheets/895dac3e-2ad5-4f1a-96e7-ae12687b0cfa/tabs/Categories/Category_ID/{category_id}:
+    patch:
+      tags: [Taxonomy-Categories]
+      operationId: updateCategoryById
+      summary: Update Taxonomy - Categories
+      parameters:
+        - in: path
+          name: category_id
+          required: true
+          schema: { type: string }
+          description: Exact value of the Category_ID column
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/TaxonomyCategoryUpdate' }
+      responses:
+        "200":
+          description: Updated row(s)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TaxonomyCategory' }
+
+  # ===================== SUBCATEGORIES (Taxonomy) =====================
+  /sheets/895dac3e-2ad5-4f1a-96e7-ae12687b0cfa/tabs/Subcategories:
+    get:
+      tags: [Taxonomy-Subcategories]
+      operationId: listSubcategories
+      summary: Get Taxonomy - Subcategories
+      parameters:
+        - in: query
+          name: _limit
+          schema: { type: integer, minimum: 1 }
+        - in: query
+          name: _offset
+          schema: { type: integer, minimum: 0 }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TaxonomySubcategory' }
+
+  /sheets/895dac3e-2ad5-4f1a-96e7-ae12687b0cfa/tabs/Subcategories/Subcategory_ID/{subcategory_id}:
+    patch:
+      tags: [Taxonomy-Subcategories]
+      operationId: updateSubcategoryById
+      summary: Update Taxonomy - Subcategories
+      parameters:
+        - in: path
+          name: subcategory_id
+          required: true
+          schema: { type: string }
+          description: Exact value of the Subcategory_ID column
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/TaxonomySubcategoryUpdate' }
+      responses:
+        "200":
+          description: Updated row(s)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/TaxonomySubcategory' }
+
+  # ===================== FEEDBACK ITEMS (existing actions retained) =====================
+  /sheets/e1b92735-b604-4564-a285-c0e5c2614cb0:
+    get:
+      tags: [FeedbackItems]
+      operationId: listFeedbackItems
+      summary: List feedback items (use Sheet.best query params for filtering)
+      parameters:
+        - in: query
+          name: _limit
+          schema: { type: integer, minimum: 1, default: 20 }
+        - in: query
+          name: _offset
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FeedbackItem' }
+    post:
+      tags: [FeedbackItems]
+      operationId: createFeedbackItem
+      summary: Insert one or many structured feedback items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FeedbackItem' }
+      responses:
+        "200":
+          description: Inserted row(s) as returned by Sheet.best
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FeedbackItem' }
+
+  /sheets/e1b92735-b604-4564-a285-c0e5c2614cb0/Feedback_Item_ID/{feedback_item_id}:
+    patch:
+      tags: [FeedbackItems]
+      operationId: updateFeedbackItem
+      summary: Update a single Feedback Item (e.g., set Type and/or Subject_ID)
+      parameters:
+        - in: path
+          name: feedback_item_id
+          required: true
+          schema: { type: string }
+          description: Exact value of the Feedback_Item_ID column (URL-encode if needed)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FeedbackItemUpdate' }
+      responses:
+        "200":
+          description: Updated row(s)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FeedbackItem' }
+
+  /sheets/e1b92735-b604-4564-a285-c0e5c2614cb0/Subject_ID/{subject_id}:
+    patch:
+      tags: [FeedbackItems]
+      operationId: bulkUpdateFeedbackItemsBySubjectID
+      summary: Bulk retag all Feedback Items currently using a given Subject_ID
+      description: Switch all rows from old Subject_ID to a new canonical Subject_ID.
+      parameters:
+        - in: path
+          name: subject_id
+          required: true
+          schema: { type: string }
+          description: Old Subject_ID (the one currently present on the rows to update)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/BulkFeedbackItemRetag' }
+      responses:
+        "200":
+          description: Updated rows
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FeedbackItem' }


### PR DESCRIPTION

What changed?

Added openapi/v2.3.0.yaml with updated schema (new TaxonomySubcategoryUpdate fields).

Bumped info.version to 2.3.0.

Updated FeedbackItem schema examples.

Why was this change made?

Align schema with new feedback processing instructions.

Prepare for next rollout of CustomGPT Actions.

How was it tested?

Ran redocly lint and spectral lint locally.

Verified schema imports correctly into CustomGPT.

Additional notes (optional):

This PR should be merged before updating Pages to serve v2.3.0.

Next step: update latest.yaml to point to v2.3.0.