### PR TITLE
Fix path parameter definitions in v3.0.0 spec

### DIFF
--- a/v3.0.0.yaml
+++ b/v3.0.0.yaml
@@ -177,12 +177,17 @@ paths:
   ############################
 
   /sheets/{termsSheetId}:
+    parameters:
+      - name: termsSheetId
+        in: path
+        required: true
+        description: Taxonomy Terms sheet ID (e.g., 895dac3e-2ad5-4f1a-96e7-ae12687b0cfa)
+        schema:
+          type: string
     get:
       operationId: listTerms
       summary: List Terms
       description: List Terms with optional client-side filtering.
-      parameters:
-        - $ref: '#/components/parameters/TermsSheetIdParam'
       responses:
         '200':
           description: OK
@@ -194,8 +199,6 @@ paths:
     post:
       operationId: createTerm
       summary: Create Term
-      parameters:
-        - $ref: '#/components/parameters/TermsSheetIdParam'
       requestBody:
         required: true
         content:
@@ -205,12 +208,22 @@ paths:
         '201': { description: Created }
 
   /sheets/{termsSheetId}/Term_ID/{Term_ID}:
+    parameters:
+      - name: termsSheetId
+        in: path
+        required: true
+        description: Taxonomy Terms sheet ID (e.g., 895dac3e-2ad5-4f1a-96e7-ae12687b0cfa)
+        schema:
+          type: string
+      - name: Term_ID
+        in: path
+        required: true
+        description: Primary key of a Term row
+        schema:
+          type: string
     patch:
       operationId: updateTerm
       summary: Update Term by Term_ID
-      parameters:
-        - $ref: '#/components/parameters/TermsSheetIdParam'
-        - $ref: '#/components/parameters/TermIdParam'
       requestBody:
         required: true
         content:
@@ -224,11 +237,16 @@ paths:
   ##################################
 
   /sheets/{feedbackSheetId}:
+    parameters:
+      - name: feedbackSheetId
+        in: path
+        required: true
+        description: Feedback Items sheet ID (e.g., e1b92735-b604-4564-a285-c0e5c2614cb0)
+        schema:
+          type: string
     get:
       operationId: listFeedbackItems
       summary: List Feedback Items
-      parameters:
-        - $ref: '#/components/parameters/FeedbackSheetIdParam'
       responses:
         '200':
           description: OK
@@ -240,8 +258,6 @@ paths:
     post:
       operationId: createFeedbackItem
       summary: Create Feedback Item
-      parameters:
-        - $ref: '#/components/parameters/FeedbackSheetIdParam'
       requestBody:
         required: true
         content:
@@ -251,12 +267,22 @@ paths:
         '201': { description: Created }
 
   /sheets/{feedbackSheetId}/Feedback_ID/{Feedback_ID}:
+    parameters:
+      - name: feedbackSheetId
+        in: path
+        required: true
+        description: Feedback Items sheet ID (e.g., e1b92735-b604-4564-a285-c0e5c2614cb0)
+        schema:
+          type: string
+      - name: Feedback_ID
+        in: path
+        required: true
+        description: Primary key of a Feedback row
+        schema:
+          type: string
     patch:
       operationId: updateFeedbackItem
       summary: Update Feedback Item by Feedback_ID
-      parameters:
-        - $ref: '#/components/parameters/FeedbackSheetIdParam'
-        - $ref: '#/components/parameters/FeedbackIdParam'
       requestBody:
         required: true
         content:
@@ -269,14 +295,24 @@ paths:
   # BULK REMAP: FeedbackItems by (old) Term_ID → new
   ###################################################
   /sheets/{feedbackSheetId}/Term_ID/{Term_ID}:
+    parameters:
+      - name: feedbackSheetId
+        in: path
+        required: true
+        description: Feedback Items sheet ID (e.g., e1b92735-b604-4564-a285-c0e5c2614cb0)
+        schema:
+          type: string
+      - name: Term_ID
+        in: path
+        required: true
+        description: Primary key of a Term row
+        schema:
+          type: string
     patch:
       operationId: bulkRemapFeedbackItemsByTerm
       summary: Bulk update FeedbackItems where Term_ID == old Term_ID
       description: >
         Use for canonicalization: remap all FeedbackItems from a deprecated Term to its Canonical_ID.
-      parameters:
-        - $ref: '#/components/parameters/FeedbackSheetIdParam'
-        - $ref: '#/components/parameters/TermIdParam'
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- add explicit path-level parameter declarations for each sheet-based endpoint in the v3.0.0 OpenAPI document
- ensure every operation inherits parameters with proper names so client generators no longer skip these routes

## Testing
- not run (OpenAPI spec change only)


------
https://chatgpt.com/codex/tasks/task_b_68d3351f4e188329a9f732b65137b95d