### PR TITLE
Inline path parameters for patch operations

### DIFF
--- a/v3.0.0.yaml
+++ b/v3.0.0.yaml
@@ -193,7 +193,12 @@ paths:
       operationId: updateTerm
       summary: Update Term by Term_ID
       parameters:
-        - $ref: '#/components/parameters/TermIdParam'
+        - name: Term_ID
+          in: path
+          required: true
+          description: Primary key of a Term row
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -234,7 +239,12 @@ paths:
       operationId: updateFeedbackItem
       summary: Update Feedback Item by Feedback_ID
       parameters:
-        - $ref: '#/components/parameters/FeedbackIdParam'
+        - name: Feedback_ID
+          in: path
+          required: true
+          description: Primary key of a Feedback row
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -253,7 +263,12 @@ paths:
       description: >
         Use for canonicalization: remap all FeedbackItems from a deprecated Term to its Canonical_ID.
       parameters:
-        - $ref: '#/components/parameters/TermIdParam'
+        - name: Term_ID
+          in: path
+          required: true
+          description: Primary key of a Term row
+          schema:
+            type: string
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- inline the Term_ID and Feedback_ID path parameter definitions on the patch endpoints so the OpenAPI linter can read their names

## Testing
- ⚠️ `python -c "import yaml,sys; yaml.safe_load(open('v3.0.0.yaml'))"` *(fails: PyYAML not available and installation is blocked by the environment proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68d33734d9308329977c84b60bcdfb64