### PR TITLE
Fix patch parameter references for Custom GPT parser

### DIFF
--- a/v3.0.0.yaml
+++ b/v3.0.0.yaml
@@ -275,11 +275,11 @@ paths:
           application/json:
             schema:
               type: object
-              required: [ Term_ID, Updated_At ]
+              required: [ Canonical_Term_ID, Updated_At ]
               properties:
-                Term_ID:
+                Canonical_Term_ID:
                   type: string
-                  description: "The *new* canonical Term_ID to set"
+                  description: "The *new* canonical Term_ID to set on matching FeedbackItems"
                 Updated_At:
                   type: string
                   format: date-time


### PR DESCRIPTION
## Summary
- inline the path parameters for each PATCH endpoint so the Custom GPT action schema no longer reports unrecognized parameters
- rename the bulk remap request body field to `Canonical_Term_ID` to avoid colliding with the path parameter while keeping its intent clear

## Testing
- `ruby -ryaml -e "YAML.load_file('v3.0.0.yaml'); puts 'YAML OK'"`


------
https://chatgpt.com/codex/tasks/task_b_68d3386e2654832989befba0962f655a