### PR TITLE
Add FeedbackItem Term_ID validation and remap rules

### DIFF
--- a/v3.0.0.yaml
+++ b/v3.0.0.yaml
@@ -76,6 +76,19 @@ components:
         Created_By:  { type: string }
         Created_At:  { type: string, format: date-time }
         Updated_At:  { type: string, format: date-time }
+      x-validationRules:
+        - name: feedback_term_id_must_exist
+          summary: "When Term_ID is supplied, it must reference an existing Term row."
+          expression: "Term_ID is null or term exists"
+        - name: feedback_term_must_resolve_to_active
+          summary: "Reject Draft Terms. Deprecated Terms remap to Canonical_ID when present; otherwise reject the write."
+          expression: "Term_ID is null or term.Status = 'Active' or (term.Status = 'Deprecated' and term.Canonical_ID is not null)"
+      x-writeTransforms:
+        - name: remap_feedback_term_to_canonical
+          summary: "If a deprecated Term with a Canonical_ID is provided, automatically replace Term_ID with the canonical value before persisting."
+          when: "term.Status = 'Deprecated' and term.Canonical_ID is not null"
+          set:
+            Term_ID: "term.Canonical_ID"
 
     FeedbackItemUpdate:
       type: object
@@ -101,6 +114,19 @@ components:
           maximum: 1
           description: "Confidence for the assigned Term"
         Updated_At:  { type: string, format: date-time }
+      x-validationRules:
+        - name: feedback_update_term_id_must_exist
+          summary: "If Term_ID is included in the update payload, it must reference an existing Term row."
+          expression: "Term_ID is null or term exists"
+        - name: feedback_update_term_must_resolve_to_active
+          summary: "Reject Draft Terms. Deprecated Terms remap to Canonical_ID when present; otherwise reject the write."
+          expression: "Term_ID is null or term.Status = 'Active' or (term.Status = 'Deprecated' and term.Canonical_ID is not null)"
+      x-writeTransforms:
+        - name: remap_feedback_update_term_to_canonical
+          summary: "When Term_ID references a deprecated Term with Canonical_ID, automatically set Term_ID to the canonical value before persisting."
+          when: "term.Status = 'Deprecated' and term.Canonical_ID is not null"
+          set:
+            Term_ID: "term.Canonical_ID"
 
     Term:
       type: object


### PR DESCRIPTION
## Summary
- specify validation that FeedbackItem Term_ID references existing Terms and resolves to an active record
- document automatic remapping for deprecated Terms that provide a Canonical_ID during create and update flows

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d42c16573483298779a7c55c8de4c2