### PR TITLE
Fix bulk feedback request schema

### DIFF
--- a/v3.0.0.yaml
+++ b/v3.0.0.yaml
@@ -390,24 +390,37 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              minItems: 1
-              items: { $ref: '#/components/schemas/FeedbackItem' }
+              type: object
+              required: [ items ]
+              properties:
+                items:
+                  type: array
+                  minItems: 1
+                  description: "Array of Feedback Items to insert or update via idempotency hash."
+                  items: { $ref: '#/components/schemas/FeedbackItem' }
       responses:
         '201':
           description: Created rows
           content:
             application/json:
               schema:
-                type: array
-                items: { $ref: '#/components/schemas/FeedbackItem' }
+                type: object
+                required: [ items ]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/FeedbackItem' }
         '200':
           description: Existing rows updated via idempotency hash collision
           content:
             application/json:
               schema:
-                type: array
-                items: { $ref: '#/components/schemas/FeedbackItem' }
+                type: object
+                required: [ items ]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/FeedbackItem' }
 
   /sheets/e1b92735-b604-4564-a285-c0e5c2614cb0/Feedback_ID/{Feedback_ID}:
     patch:


### PR DESCRIPTION
## Summary
- wrap the bulk feedback create request body in an object with an `items` array to satisfy object-schema requirements
- align the bulk create responses with the new object envelope for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d702a872a8832991e21f81e4125f33