### PR TITLE
Ensure new taxonomy terms default to Active

### DIFF
--- a/Instructions_v3.0.md
+++ b/Instructions_v3.0.md
@@ -78,7 +78,7 @@ Transform raw, unstructured customer feedback into structured rows stored in the
   - Example: `"teamwork; collaboration tools; co-authoring"`
 - **Status** (`string`)
   - Enum: `Active`, `Deprecated`, `Draft`
-  - Description: Lifecycle state. Deprecated terms should point to `Canonical_ID` for automatic remapping; `Draft` is not yet used for mapping.
+  - Description: Lifecycle state. **Always create new Terms with `Status = "Active"` so they can be mapped immediately.** Deprecated terms should point to `Canonical_ID` for automatic remapping; `Draft` is reserved for manual staging and should not be used by the GPT.
   - Example: `"Active"`
 - **Parent_ID** (`string`, nullable)
   - Description: Identifier of the parent term. `NULL` for `Level = 1`. Must reference `Level = 1` when `Level = 2`, and `Level = 2` when `Level = 3`.

--- a/v2.3.0.yaml
+++ b/v2.3.0.yaml
@@ -22,7 +22,11 @@ components:
         Subject_ID:           { type: string, description: "UUID, subj_xxxx" }
         Subject_Name:         { type: string, description: "Specific taxonomy subject name (ideally unique)" }
         Synonyms:             { type: string, description: "Comma/semicolon-separated alternates" }
-        Status:               { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Status:
+          type: string
+          enum: ["Draft", "Active", "Deleted"]
+          default: "Active"
+          description: "Lifecycle state. Create new Subjects as Active; reserve Draft for manual staging workflows."
         Category_ID:          { type: string, nullable: true, description: "FK to Categories (Status=Active)" }
         Subcategory_ID:       { type: string, nullable: true, description: "FK to Subcategories (Status=Active)" }
         Notes:                { type: string, description: "Free text; record merge actions here" }
@@ -39,7 +43,10 @@ components:
       properties:
         Subject_Name:         { type: string }
         Synonyms:             { type: string }
-        Status:               { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Status:
+          type: string
+          enum: ["Draft", "Active", "Deleted"]
+          description: "Lifecycle state. Use Active for new Subjects; Draft remains for manual staging."
         Category_ID:          { type: string, nullable: true }
         Subcategory_ID:       { type: string, nullable: true }
         Notes:                { type: string }
@@ -58,7 +65,11 @@ components:
         Category_ID:           { type: string, description: "UUID, like cat_001" }
         Canonical_Category_ID: { type: string, nullable: true, description: "FK to canonical Category_ID when merged/deleted" }
         Description:           { type: string, description: "Description of the category to guide mapping" }
-        Status:                { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Status:
+          type: string
+          enum: ["Draft", "Active", "Deleted"]
+          default: "Active"
+          description: "Lifecycle state. Create new Categories as Active; Draft is for manual staging only."
         Created_By:            { type: string, description: "Person or Machine who created the record" }
         Created_At:            { type: string, description: "ISO-8601 timestamp" }
         Updated_At:            { type: string, description: "ISO-8601 timestamp" }
@@ -73,7 +84,10 @@ components:
         Category_Name:         { type: string }
         Canonical_Category_ID: { type: string, nullable: true }
         Description:           { type: string }
-        Status:                { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Status:
+          type: string
+          enum: ["Draft", "Active", "Deleted"]
+          description: "Lifecycle state. Keep new Categories Active; Draft reserved for manual staging."
         Created_By:            { type: string }
         Created_At:            { type: string }
         Updated_At:            { type: string }
@@ -90,7 +104,11 @@ components:
         Category_ID:              { type: string, nullable: true, description: "FK to Categories (Status=Active)" }
         Canonical_Subcategory_ID: { type: string, nullable: true, description: "FK to canonical Subcategory_ID when merged/deleted" }
         Description:              { type: string, description: "Description to guide mapping" }
-        Status:                   { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Status:
+          type: string
+          enum: ["Draft", "Active", "Deleted"]
+          default: "Active"
+          description: "Lifecycle state. Create new Subcategories as Active; Draft is reserved for manual staging."
         Created_By:               { type: string, description: "Person or Machine who created the record" }
         Created_At:               { type: string, description: "ISO-8601 timestamp" }
         Updated_At:               { type: string, description: "ISO-8601 timestamp" }
@@ -106,7 +124,10 @@ components:
         Category_ID:              { type: string, nullable: true }
         Canonical_Subcategory_ID: { type: string, nullable: true }
         Description:              { type: string }
-        Status:                   { type: string, enum: ["Draft", "Active", "Deleted"] }
+        Status:
+          type: string
+          enum: ["Draft", "Active", "Deleted"]
+          description: "Lifecycle state. Use Active for new Subcategories; Draft reserved for manual staging."
         Created_By:               { type: string }
         Created_At:               { type: string }
         Updated_At:               { type: string }

--- a/v3.0.0.yaml
+++ b/v3.0.0.yaml
@@ -155,6 +155,8 @@ components:
         Status:
           type: string
           enum: [Active, Deprecated, Draft]
+          default: Active
+          description: "Lifecycle state. Send 'Active' when creating new Terms; use 'Deprecated' only when remapping, and reserve 'Draft' for manual staging."
         Parent_ID:    { type: string, nullable: true, description: "NULL for Level=1; Level 2→L1; Level 3→L2" }
         Canonical_ID: { type: string, nullable: true, description: "Active replacement for Deprecated terms (must differ from Term_ID)" }
         Ordinal:     { type: integer, minimum: 0, nullable: true }


### PR DESCRIPTION
## Summary
- update the instructions to direct the GPT to create new taxonomy terms with Active status instead of Draft
- set Active as the default status for taxonomy entities in the v2.3 and v3.0 OpenAPI specs and clarify the guidance in their descriptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d70f4db3c083299b17f3a793e79ec9